### PR TITLE
chore: change content of CODEOWNERS to be compliant

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-# The codebase is owned by the Governance & Identity Experience team at DFINITY
-# For questions, reach out to: <gix@dfinity.org>
+* @dfinity/gix


### PR DESCRIPTION
The format needs to pass a compliance check of
https://github.com/dfinity/repositories-open-to-contributions which is why it needs to be adjusted here.