### PR TITLE
feat: the "add recovery phrase" question was removed from the sign-in flow

### DIFF
--- a/src/page-objects/InternetIdentityPage.ts
+++ b/src/page-objects/InternetIdentityPage.ts
@@ -145,7 +145,6 @@ export class InternetIdentityPage {
     await expect(iiPage).toHaveTitle('Internet Identity');
 
     await iiPage.locator(`[data-anchor-id='${identity}']`).click();
-    await iiPage.locator('[data-action=cancel]').click();
     await iiPage.waitForEvent('close');
     expect(iiPage.isClosed()).toBe(true);
   };


### PR DESCRIPTION
# Motivation

I have updated the version of Internet Identity to the latest in the Juno Docker image. As a result, the E2E tests in this repository started failing. After analysis, it appears that the prompt to add a recovery phrase after a returning user signs in has been removed from the Internet Identity flow. Assuming this was an intentional decision, this PR removes the test call to 'Cancel,' as this step is no longer presented.