### PR TITLE
feat: invert types order in export

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/types/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
# Motivation

Resolve the warning throws by the newest version of `esbuild` when building the project:

> ▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    package.json:39:6:
      39 │       "types": "./dist/types/index.d.ts"
         ╵       ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    package.json:37:6:
      37 │       "import": "./dist/index.js",
         ╵       ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    package.json:38:6:
      38 │       "require": "./dist/index.js",