### PR TITLE
fix: hanging CI by using juno dev start --headless

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run tests
         run: |
           cd demo
-          juno dev start &
+          juno dev start --headless &
           cd ..
           npm run e2e:ci
 


### PR DESCRIPTION
# Motivation

Tests were failing as the CI was hanging for ever because `juno dev start` was hanging. This was due to a new feature of the CLI which was not detecting non interactive mode.