### PR TITLE
feat: expect no captcha per default in sign-in flow

### DIFF
--- a/src/page-objects/InternetIdentityPage.ts
+++ b/src/page-objects/InternetIdentityPage.ts
@@ -114,7 +114,7 @@ export class InternetIdentityPage {
     await iiPage.locator('[data-action=construct-identity]').click();
 
     if (params?.captcha === true) {
-      await iiPage.locator('input#captchaInput').fill('a');
+      await iiPage.locator('input#captchaInput').fill('a', {timeout: 10000});
       await iiPage.locator('#confirmRegisterButton').click();
     }
 

--- a/src/page-objects/InternetIdentityPage.ts
+++ b/src/page-objects/InternetIdentityPage.ts
@@ -96,9 +96,13 @@ export class InternetIdentityPage {
    *
    * @param {Object} [params] - The optional arguments for the sign-in method.
    * @param {string} [params.selector] - The selector for the login button. Defaults to [data-tid=login-button].
+   * @param {boolean} [params.captcha] - Set to true if the II login flow requires a captcha.
    * @returns {Promise<number>} A promise that resolves to the new identity number.
    */
-  signInWithNewIdentity = async (params?: {selector?: string}): Promise<number> => {
+  signInWithNewIdentity = async (params?: {
+    selector?: string;
+    captcha?: boolean;
+  }): Promise<number> => {
     const iiPagePromise = this.context.waitForEvent('page');
 
     await this.page.locator(params?.selector ?? '[data-tid=login-button]').click();
@@ -109,8 +113,10 @@ export class InternetIdentityPage {
     await iiPage.locator('#registerButton').click();
     await iiPage.locator('[data-action=construct-identity]').click();
 
-    await iiPage.locator('input#captchaInput').fill('a');
-    await iiPage.locator('#confirmRegisterButton').click();
+    if (params?.captcha === true) {
+      await iiPage.locator('input#captchaInput').fill('a');
+      await iiPage.locator('#confirmRegisterButton').click();
+    }
 
     const identity = await iiPage.locator('#userNumber').textContent();
     expect(identity).not.toBeNull();


### PR DESCRIPTION
# Motivation

The latest version of II can be configured to skip captcha verification when creating a new identity in local development. This is probably the developer experience we aim to promote, so this PR introduces a new `captcha` option, which is disabled by default.

Additionally, this PR updates the E2E CI checks to reflect that Juno Docker now skips captcha verification by default.