### PR TITLE
test: new method to manually log in with an existing identity

### DIFF
--- a/src/page-objects/InternetIdentityPage.ts
+++ b/src/page-objects/InternetIdentityPage.ts
@@ -153,4 +153,26 @@ export class InternetIdentityPage {
     await iiPage.waitForEvent('close');
     expect(iiPage.isClosed()).toBe(true);
   };
+  manuallySignInWithIdentity = async ({
+    selector,
+    identity
+  }: {
+    selector?: string;
+    identity: number;
+  }): Promise<void> => {
+    const iiPagePromise = this.context.waitForEvent('page');
+
+    await this.page.locator(selector ?? '[data-tid=login-button]').click();
+
+    const iiPage = await iiPagePromise;
+    await expect(iiPage).toHaveTitle('Internet Identity');
+
+    await iiPage.locator(selector ?? '[data-role="more-options"]').click();
+    await iiPage.fill('input[data-role="anchor-input"]', identity.toString());
+    await iiPage.locator(selector ?? '[data-action="continue"]').click();
+    await iiPage.waitForEvent('close');
+    expect(iiPage.isClosed()).toBe(true);
+  };
 }
+
+


### PR DESCRIPTION
For the new e2e environment of OISY Wallet, we need a way to manually sign in with an existing II. This could be done in a way such as this.