### PR TITLE
dependabot: Add Dependabot configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/en/enterprise-cloud@latest/code-security/dependabot/dependabot-version-updates
+
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: monthly
+    allow:
+      - dependency-type: development
+    ignore:
+      - dependency-name: '@types/*'
+      - dependency-name: '@typescript-eslint/*'
+      - dependency-name: 'eslint'
+      - dependency-name: 'eslint-*'
+    commit-message:
+      prefix: 'build'
+
+  - package-ecosystem: npm
+    directory: '/demo'
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: '@types/*'
+      - dependency-name: '@typescript-eslint/*'
+      - dependency-name: 'eslint'
+      - dependency-name: 'eslint-*'
+    commit-message:
+      prefix: 'build'


### PR DESCRIPTION
I would like to propose using Dependaobt monthly: only dev-dependencies for the entire repo and all the dependencies for the `demo`.