### PR TITLE
build: bump Playwright

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@playwright/test": "^1"
+        "@playwright/test": "^1.52.0"
       }
     },
     "node_modules/@dfinity/agent": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@playwright/test": "^1.44.1"
+        "@playwright/test": "^1"
       }
     },
     "node_modules/@dfinity/agent": {
@@ -865,19 +865,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.1.tgz",
-      "integrity": "sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "playwright": "1.44.1"
+        "playwright": "1.52.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -4112,35 +4112,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
-      "integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "playwright-core": "1.44.1"
+        "playwright-core": "1.52.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
-      "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "node": ">=22"
   },
   "peerDependencies": {
-    "@playwright/test": "^1.44.1"
+    "@playwright/test": "^1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "node": ">=22"
   },
   "peerDependencies": {
-    "@playwright/test": "^1"
+    "@playwright/test": "^1.52.0"
   }
 }


### PR DESCRIPTION
We want to keep the pace. We also bump the requirement because Playwright v1.51.0 uses IDB. We might use this option in the future to support re-entering login.