### PR TITLE
feat: support for latest II and create passkey option

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
           key: ${{ runner.os }}-docker-default-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-docker-default-
-      - name: Run tests without captcha
+      - name: Run default tests
         run: |
           cd demo
           docker compose up -d
@@ -55,8 +55,33 @@ jobs:
           cd ..
           npm run e2e:captcha:ci
 
+  tests_passkey:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Prepare
+        uses: ./.github/actions/prepare
+      - name: Install demo dependencies
+        run: npm ci
+        working-directory: demo
+      - name: Cache Docker layers for passkey image
+        uses: actions/cache@v3
+        with:
+          path: /home/runner/.docker
+          key: ${{ runner.os }}-docker-passkey-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-docker-passkey-
+      - name: Run tests with passkey
+        run: |
+          cd demo
+          docker compose -f docker-compose.passkey.yml up -d
+          cd ..
+          npm run e2e:passkey:ci
+
   may-merge:
-    needs: ['tests', 'tests_captcha']
+    needs: ['tests', 'tests_captcha', 'tests_passkey']
     runs-on: ubuntu-latest
     steps:
       - name: Cleared for merging

--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ testWithII('should sign-in with a new user when II requires a captcha', async ({
 });
 ```
 
+Similarly, you can test a flow where Internet Identity requires the user to create and save a passkey:
+
+```javascript
+testWithII('should sign in with a new user when II requires a passkey', async ({page, iiPage}) => {
+  await page.goto('/');
+
+  await iiPage.signInWithNewIdentity({createPasskey: true});
+});
+```
+
 ### 3. Wait for Internet Identity (optional)
 
 You might encounter scenarios where you perform tests against a local replica started in parallel with your tests, commonly when automating the tests in a CI environment. The library also exposes a fixture that lets you wait for Internet Identity to be ready.
@@ -165,6 +175,20 @@ Then, navigate to the root directory and run the dedicated test:
 
 ```bash
 npm run e2e:captcha
+```
+
+### Running Required Passkey Tests Locally
+
+The default test suite validates the use of the latest Internet Identity, which does not require the user to complete a specific step to create a passkey. To test a flow where passkey creation is required, run the following command from the `demo` directory:
+
+```bash
+docker compose -f docker-compose.passkey.yml up
+```
+
+Then, navigate to the root directory and run the dedicated test:
+
+```bash
+npm run e2e:passkey
 ```
 
 ## 🚧 Limitations

--- a/demo/docker-compose.passkey.yml
+++ b/demo/docker-compose.passkey.yml
@@ -1,0 +1,12 @@
+services:
+  juno-satellite:
+    image: junobuild/satellite:0.0.57
+    ports:
+      - 5987:5987
+    volumes:
+      - juno_satellite_passkey:/juno/.juno
+      - ./juno.dev.config.js:/juno/juno.dev.config.js
+      - ./target/deploy:/juno/target/deploy/
+
+volumes:
+  juno_satellite_passkey:

--- a/e2e/captcha.spec.ts
+++ b/e2e/captcha.spec.ts
@@ -8,5 +8,5 @@ testWithII.beforeEach(async ({iiPage}) => {
 testWithII('should sign-in with a new user when II requires a captcha', async ({page, iiPage}) => {
   await page.goto('/');
 
-  await iiPage.signInWithNewIdentity({captcha: true});
+  await iiPage.signInWithNewIdentity({captcha: true, createPasskey: true});
 });

--- a/e2e/passkey.spec.ts
+++ b/e2e/passkey.spec.ts
@@ -1,10 +1,8 @@
 import {testWithII} from '../src';
+import {DOCKER_CONTAINER} from './spec.constants';
 
 testWithII.beforeEach(async ({iiPage}) => {
-  const DOCKER_CONTAINER_URL = 'http://127.0.0.1:5987';
-  const DOCKER_INTERNET_IDENTITY_ID = 'rdmx6-jaaaa-aaaaa-aaadq-cai';
-
-  await iiPage.waitReady({url: DOCKER_CONTAINER_URL, canisterId: DOCKER_INTERNET_IDENTITY_ID});
+  await iiPage.waitReady(DOCKER_CONTAINER);
 });
 
 testWithII('should sign-in with a new user when II requires a passkey', async ({page, iiPage}) => {

--- a/e2e/passkey.spec.ts
+++ b/e2e/passkey.spec.ts
@@ -1,0 +1,14 @@
+import {testWithII} from '../src';
+
+testWithII.beforeEach(async ({iiPage}) => {
+  const DOCKER_CONTAINER_URL = 'http://127.0.0.1:5987';
+  const DOCKER_INTERNET_IDENTITY_ID = 'rdmx6-jaaaa-aaaaa-aaadq-cai';
+
+  await iiPage.waitReady({url: DOCKER_CONTAINER_URL, canisterId: DOCKER_INTERNET_IDENTITY_ID});
+});
+
+testWithII('should sign-in with a new user when II requires a passkey', async ({page, iiPage}) => {
+  await page.goto('/');
+
+  await iiPage.signInWithNewIdentity({createPasskey: true});
+});

--- a/package.json
+++ b/package.json
@@ -46,10 +46,12 @@
     "build": "tsc --noEmit && node rmdir.mjs && node esbuild.mjs && npm run ts-declaration",
     "lint": "eslint --max-warnings 0 \"src/**/*\"",
     "dev": "npm --prefix demo run dev",
-    "e2e": "NODE_ENV=development playwright test --grep-invert 'captcha'",
-    "e2e:ci": "playwright test --reporter=html --grep-invert 'captcha'",
+    "e2e": "NODE_ENV=development playwright test e2e/login.spec",
+    "e2e:ci": "playwright test --reporter=html e2e/login.spec",
     "e2e:captcha": "NODE_ENV=development playwright test e2e/captcha.spec",
-    "e2e:captcha:ci": "playwright test --reporter=html e2e/captcha.spec"
+    "e2e:captcha:ci": "playwright test --reporter=html e2e/captcha.spec",
+    "e2e:passkey": "NODE_ENV=development playwright test e2e/passkey.spec",
+    "e2e:passkey:ci": "playwright test --reporter=html e2e/passkey.spec"
   },
   "devDependencies": {
     "@dfinity/eslint-config-oisy-wallet": "^0.1.10",

--- a/src/page-objects/InternetIdentityPage.ts
+++ b/src/page-objects/InternetIdentityPage.ts
@@ -99,11 +99,13 @@ export class InternetIdentityPage {
    * @param {Object} [params] - The optional arguments for the sign-in method.
    * @param {string} [params.selector] - The selector for the login button. Defaults to [data-tid=login-button].
    * @param {boolean} [params.captcha] - Set to true if the II login flow requires a captcha.
+   * @param {boolean} [params.createPasskey] - Set to true if the II login flow requires the user to create a passkey.
    * @returns {Promise<number>} A promise that resolves to the new identity number.
    */
   signInWithNewIdentity = async (params?: {
     selector?: string;
     captcha?: boolean;
+    createPasskey?: boolean;
   }): Promise<number> => {
     const iiPagePromise = this.context.waitForEvent('page');
 
@@ -114,7 +116,10 @@ export class InternetIdentityPage {
     await expect(iiPage).toHaveTitle('Internet Identity');
 
     await iiPage.locator('#registerButton').click();
-    await iiPage.locator('[data-action=construct-identity]').click();
+
+    if (params?.createPasskey === true) {
+      await iiPage.locator('[data-action=construct-identity]').click();
+    }
 
     if (params?.captcha === true) {
       await iiPage.locator('input#captchaInput').fill('a', {timeout: 10000});


### PR DESCRIPTION
# Motivation

In one of the latest Internet Identity releases, the flow was modified to no longer require the user to create and save a passkey as a dedicated step. As a result, this plugin is incompatible with the new flow, as reported in [#56](#56).

# Breaking Changes

This PR introduces a breaking change because Internet Identity itself has introduced a breaking change—i.e., we now assume the new behavior is the standard moving forward.

# Changes

- Add an option to use a flow that explicitly requires the passkey creation step. This is useful when using older versions of Internet Identity.
- Default to **not** using the passkey-required step to align with the latest II behavior.
- Add a dedicated test and setup to validate this new option.
- Document new option.
