### PR TITLE
chore: set v2.0.0 for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/internet-identity-playwright",
-  "version": "0.0.5",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/internet-identity-playwright",
-      "version": "0.0.5",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/internet-identity-playwright",
-  "version": "0.0.5",
+  "version": "2.0.0",
   "description": "A Playwright library to simplify the integration of Internet Identity authentication in E2E tests.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
# Motivation

We want to release the fix for #60, which is why we're bumping the version. We're also starting to use semantic versioning. Since the fix is a breaking change required by another one that was already shipped in Internet Identity, we're going straight to version v2.0.0.