### PR TITLE
chore: set tailwind version

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -18,7 +18,7 @@
         "@tailwindcss/vite": "^4.1.8",
         "autoprefixer": "^10.4.21",
         "prettier": "^3.5.3",
-        "tailwindcss": "^4.1.6",
+        "tailwindcss": "^4.1.8",
         "vite": "^6.3.5",
         "vite-plugin-node-polyfills": "^0.23.0"
       }

--- a/demo/package.json
+++ b/demo/package.json
@@ -17,7 +17,7 @@
     "@tailwindcss/vite": "^4.1.8",
     "autoprefixer": "^10.4.21",
     "prettier": "^3.5.3",
-    "tailwindcss": "^4.1.6",
+    "tailwindcss": "^4.1.8",
     "vite": "^6.3.5",
     "vite-plugin-node-polyfills": "^0.23.0"
   },


### PR DESCRIPTION
# Motivation

Not that necessary but the dependabot has upgraded tailwind as a dependency of the tailwind plugin so just setting the version.