### PR TITLE
feat: upgrade juno with latest breaking changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,10 +29,10 @@ jobs:
         run: |
           cd demo
           set -e
-          juno dev start --headless &
-          juno dev wait
+          juno emulator start --headless &
+          juno emulator wait
           juno login --emulator --mode development --headless
-          juno config --mode development --headless
+          juno config apply --mode development --headless
       - name: Run default tests
         run: npm run e2e:ci
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Navigate to the [demo](./demo) directory and start the environment:
 
 ```bash
 cd demo
-juno dev start
+juno emulator start
 ```
 
 4. Setup the environment:
@@ -175,7 +175,7 @@ If this is the first time you're running the tests locally, you need to configur
 
 ```bash
 juno login --emulator --mode development
-juno config --mode development
+juno config apply --mode development
 ```
 
 5. Run the Tests:

--- a/demo/README.md
+++ b/demo/README.md
@@ -19,13 +19,13 @@ An example developed for [Juno](https://juno.build) using vanilla JavaScript.
 
 All commands are run from the root of the project, from a terminal:
 
-| Command          | Action                                                      |
-| :--------------- | :---------------------------------------------------------- |
-| `npm install`    | Installs dependencies                                       |
-| `npm run dev`    | Starts frontend dev server at `localhost:5173`              |
-| `juno dev start` | Quickstart the local development emulator (requires Docker) |
-| `npm run build`  | Build your production site to `./dist/`                     |
-| `juno deploy`    | Deploy your project to a Satellite                          |
+| Command               | Action                                                      |
+| :-------------------- | :---------------------------------------------------------- |
+| `npm install`         | Installs dependencies                                       |
+| `npm run dev`         | Starts frontend dev server at `localhost:5173`              |
+| `juno emulator start` | Quickstart the local development emulator (requires Docker) |
+| `npm run build`       | Build your production site to `./dist/`                     |
+| `juno hosting deploy` | Deploy your project to a Satellite                          |
 
 ## 🚀 Launch
 

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -9,33 +9,18 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@junobuild/core": "^1.2.1",
+        "@junobuild/core": "^2.2.0",
         "nanoid": "^5.1.5"
       },
       "devDependencies": {
-        "@junobuild/config": "^2.1.0",
-        "@junobuild/vite-plugin": "^4.1.4",
+        "@junobuild/config": "^2.2.0",
+        "@junobuild/vite-plugin": "^4.1.5",
         "@tailwindcss/vite": "^4.1.12",
         "autoprefixer": "^10.4.21",
         "prettier": "^3.6.2",
         "tailwindcss": "^4.1.12",
         "vite": "^7.1.4",
         "vite-plugin-node-polyfills": "^0.24.0"
-      }
-    },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -55,9 +40,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
-      "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -66,23 +51,23 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
-      "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
+        "@babel/generator": "^7.28.3",
         "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.27.3",
-        "@babel/helpers": "^7.27.6",
-        "@babel/parser": "^7.28.0",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.4",
         "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.0",
-        "@babel/types": "^7.28.0",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -98,15 +83,15 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
-      "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@babel/types": "^7.28.0",
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -148,19 +133,19 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
-      "integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.3.tgz",
+      "integrity": "sha512-V9f6ZFIYSLNEbuGA/92uOvYsGCJNsuA8ESZ4ldc09bWk/j8H8TKiPw8Mk1eG6olpnO0ALHJmYfZvF4MEE4gajg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-annotate-as-pure": "^7.27.3",
         "@babel/helper-member-expression-to-functions": "^7.27.1",
         "@babel/helper-optimise-call-expression": "^7.27.1",
         "@babel/helper-replace-supers": "^7.27.1",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
+        "@babel/traverse": "^7.28.3",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -212,16 +197,16 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.3"
+        "@babel/traverse": "^7.28.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -323,29 +308,29 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
-      "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2"
+        "@babel/types": "^7.28.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/types": "^7.28.0"
+        "@babel/types": "^7.28.4"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -465,19 +450,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
-      "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
+        "@babel/generator": "^7.28.3",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.0",
+        "@babel/parser": "^7.28.4",
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.0",
+        "@babel/types": "^7.28.4",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -485,9 +470,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -500,85 +485,87 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.4.1.tgz",
-      "integrity": "sha512-IczFFOUDGfMTdQ83yiCvGtvHr1IIB80lWBP0ZYRLogs6NVt8t6HYcMlu1sgT+9VivhT7iwX4pktPFxxOkO3COw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-3.2.6.tgz",
+      "integrity": "sha512-rJscQptoa43BxHgpeyy9qF6JbAXm4tn+IeNkUE9aMn60tfy1SGizMn6UQQOmw7jvl+LYDVA6w8ZA7c2br3cM+w==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.3.1",
-        "base64-arraybuffer": "^0.2.0",
-        "borc": "^2.1.1",
-        "buffer": "^6.0.3",
-        "simple-cbor": "^0.4.1"
+        "@dfinity/cbor": "^0.2.2",
+        "@noble/curves": "^1.9.2"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^2.4.1",
-        "@dfinity/principal": "^2.4.1"
+        "@dfinity/candid": "3.2.6",
+        "@dfinity/principal": "3.2.6",
+        "@noble/hashes": "^1.8.0"
       }
     },
     "node_modules/@dfinity/auth-client": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-2.4.1.tgz",
-      "integrity": "sha512-osKgBWwMsMyQUNYhFxPqj14R2RhgdYVD0PoTGDig2sl1Hy4mQzPalCWbkW9R50vsZGmoMi/uiopvnXy036EyqA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-3.2.6.tgz",
+      "integrity": "sha512-uuo72wai9Mg5CglZ3VE9eIUibttPvFn2B7LmMFoBenT9md2d57aBUdKFep1fkHNvD4Kp4iLxOfs1UEKQX7vbog==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "idb": "^7.0.2"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.4.1",
-        "@dfinity/identity": "^2.4.1",
-        "@dfinity/principal": "^2.4.1"
+        "@dfinity/agent": "3.2.6",
+        "@dfinity/identity": "3.2.6",
+        "@dfinity/principal": "3.2.6"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.4.1.tgz",
-      "integrity": "sha512-kOaIKfhR2PYN8vD4M0Pc4s/7wb1nKjlTJUw+5E9jh26T03fITIZmaafIuwlX+wmdxwIT9Xoy7PlsxOEpzv203A==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-3.2.6.tgz",
+      "integrity": "sha512-rh26bUluupegJNiDC6pJy0wyhkctPJSJ5ue4RxnodrbA6YMyQoj7m8Ic3Y81ah/fsSXOl9AIyyVh3kMqZb3lSw==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/principal": "^2.4.1"
+        "@dfinity/principal": "3.2.6"
       }
     },
+    "node_modules/@dfinity/cbor": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/cbor/-/cbor-0.2.2.tgz",
+      "integrity": "sha512-GPJpH73kDEKbUBdUjY80lz7cq9l0vm1h/7ppejPV6O0ZTqCLrYspssYvqjRmK4aNnJ/SKXsP0rg9LYX7zpegaA==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/@dfinity/identity": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.4.1.tgz",
-      "integrity": "sha512-CXhTmdtqkA0vE6ue2GaF9ZwD0OQ5OinrGj77Eg0dX0zPZpxJQ+NCjyYNWkaIvsKxmnCaW+5yrCcchN8Sqk8uIA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-3.2.6.tgz",
+      "integrity": "sha512-18ecTwtz4Yv8coaNM4ooCzqlib9ooP20JFHJ2RVAtlWPaVcRC/4nzXTEJiUH+TytC7ZbBkuRYlJ/eLeIhyYqaA==",
       "license": "Apache-2.0",
       "peer": true,
-      "dependencies": {
-        "@noble/curves": "^1.2.0",
-        "@noble/hashes": "^1.3.1",
-        "borc": "^2.1.1"
-      },
       "peerDependencies": {
-        "@dfinity/agent": "^2.4.1",
-        "@dfinity/principal": "^2.4.1"
+        "@dfinity/agent": "3.2.6",
+        "@dfinity/candid": "3.2.6",
+        "@dfinity/principal": "3.2.6",
+        "@noble/curves": "^1.9.2",
+        "@noble/hashes": "^1.8.0"
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.4.1.tgz",
-      "integrity": "sha512-Cz6XQVOwq0TXDBClPbcidDd4SqK1lfr1/Kn34ruDD13xVQ4iaP1iCntzS9O97+vGpY/6jwDtKd32Gn5YJ9BQNw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-3.2.6.tgz",
+      "integrity": "sha512-jxEmMwZe2k/XC0DEW1i7CVJ/vPzIKT0zvXeQIBuvkfEcqWSVRiScHlURwnYStQAE1RVP8glDEs6ioeZgmEmazA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@noble/hashes": "^1.3.1"
+        "@noble/hashes": "^1.8.0"
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.14.0.tgz",
-      "integrity": "sha512-WGwME4891K9TU7SXchhUVtdSbU3jUxnndblcrNJH0/QLPuQGnvP/7YhFL1b6MhI5GRpTWh0qLsyvMpEpdw7Faw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-3.1.0.tgz",
+      "integrity": "sha512-e4Iunp147nN/gpph/7miZkxwYkctA3AyuKla0vbwK9RNJE7Rub43Zwo0mlhjYq6WHjIxIEL/8n+AAJj9+RjZcw==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/agent": "^2.0.0",
-        "@dfinity/candid": "^2.0.0",
-        "@dfinity/principal": "^2.0.0"
+        "@dfinity/agent": "^3",
+        "@dfinity/candid": "^3",
+        "@dfinity/principal": "^3"
       }
     },
     "node_modules/@dfinity/zod-schemas": {
@@ -1082,9 +1069,9 @@
       }
     },
     "node_modules/@junobuild/config": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@junobuild/config/-/config-2.1.0.tgz",
-      "integrity": "sha512-FNeRpnxcIm6iNCGHWWCoH0ZKm5nfbCvBXkfE0U90HCJnyJi4jfKSbfOcn7SrujyKkNyKQum9R9kEspc9JBv2sQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@junobuild/config/-/config-2.2.0.tgz",
+      "integrity": "sha512-nRhvQ02CdDuKL3fCGoMrY0zRc/MHOZg8Z9swIhFXyXf1cPNurNN4c5ek1okZA5okAUIchF9WXEXhVGRIU+6Lkg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1093,109 +1080,99 @@
       }
     },
     "node_modules/@junobuild/config-loader": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@junobuild/config-loader/-/config-loader-0.3.1.tgz",
-      "integrity": "sha512-UO0HFzThp/1+PztrfkkERKEbAsjaIaD+cDaeoNEB9/MJgJxnpsbpogz2X/LkQp+ecevhS3RsIbdeWWOQYhDwHA==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@junobuild/config-loader/-/config-loader-0.4.5.tgz",
+      "integrity": "sha512-ddbIyTVPCaXXwS1S/6KOE8As09Dr6O2l2x3nETgGi40uuu8Bi2+Y7NtCIfkR2U57BoHxaNqP4BAsiwUWQ0j/5g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@babel/core": "^7.26.10",
-        "@babel/plugin-transform-modules-commonjs": "^7.26.3",
-        "@babel/preset-typescript": "^7.26.0",
+        "@babel/core": "7.28.4",
+        "@babel/plugin-transform-modules-commonjs": "7.27.1",
+        "@babel/preset-typescript": "7.27.1",
         "@junobuild/config": "*"
       }
     },
     "node_modules/@junobuild/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@junobuild/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-1aWJYhCSz3eQ7e+qKhXGDZRCbQMZwpt7F+OOvKTvDMh3+NbdatjsHiPnt8xp7PRRwq1Y6lcztjvfiC7i54c8MQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@junobuild/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-G4ojJ8sf1Rzmrl1swIMyTCQ3sxBVUaNDQN8R/19AWPDyiX1TWp1uN0NrlxmQhB77TKKlLXPaiVXyQ9jut0vl1w==",
       "license": "MIT",
       "dependencies": {
         "@junobuild/errors": "*",
-        "@junobuild/ic-client": "^2",
-        "@junobuild/storage": "^1.2.0",
+        "@junobuild/ic-client": "^3",
+        "@junobuild/storage": "^1.3",
         "@junobuild/utils": "*"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.3.0",
-        "@dfinity/auth-client": "^2.3.0",
-        "@dfinity/candid": "^2.3.0",
-        "@dfinity/identity": "^2.3.0",
-        "@dfinity/principal": "^2.3.0",
-        "@dfinity/utils": "^2"
+        "@dfinity/agent": "^3.2.6",
+        "@dfinity/auth-client": "^3.2.6",
+        "@dfinity/candid": "^3.2.6",
+        "@dfinity/identity": "^3.2.6",
+        "@dfinity/principal": "^3.2.6",
+        "@dfinity/utils": "^3.1"
       }
     },
     "node_modules/@junobuild/errors": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@junobuild/errors/-/errors-0.1.1.tgz",
-      "integrity": "sha512-elHOG1d/tejSplIF2CE/Nk6Q/GguPAqA/evse+CCDyYs2AtL5mSwpzFyvwV4l2Jby2IzmcLpUac+9PD+WxdH+g==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@junobuild/errors/-/errors-0.1.4.tgz",
+      "integrity": "sha512-GZa/NF6XqcO4LkCTROLAk23cj8R0B43tOPfB9TCtm8JfgVEAMd7G66/TneeSU48JueeIxhh1NJMDNkK7JhflWA==",
       "license": "MIT"
     },
     "node_modules/@junobuild/ic-client": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@junobuild/ic-client/-/ic-client-2.0.0.tgz",
-      "integrity": "sha512-aRwG3YfdKiqH2EM53c24Ma1TC1OeP6m/Gsn7okPdICSZeKVJg8+MULkqkfKuDxfkDRvIohF9tdMCa5QUikRlew==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@junobuild/ic-client/-/ic-client-3.1.2.tgz",
+      "integrity": "sha512-Ee5/69WPZEW5p6MQ3qqg0KUbkNusEbMrm9QiAFpkEyhGUl2e/eKo7/N3I79Kz7Q8DME5CJyrP6/AMgvFJ0OLGw==",
       "license": "MIT",
       "peerDependencies": {
-        "@dfinity/agent": "^2.3.0",
-        "@dfinity/candid": "^2.3.0",
-        "@dfinity/identity": "^2.3.0",
-        "@dfinity/principal": "^2.3.0"
+        "@dfinity/agent": "^3.2.6",
+        "@dfinity/candid": "^3.2.6",
+        "@dfinity/identity": "^3.2.6",
+        "@dfinity/principal": "^3.2.6",
+        "@dfinity/utils": "^3.1"
       }
     },
     "node_modules/@junobuild/plugin-tools": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@junobuild/plugin-tools/-/plugin-tools-4.1.2.tgz",
-      "integrity": "sha512-vh2hi11amLZHo7UXjrm7zAIcAb+jMkDHbGrciE6I6NktXTK0ghhCA88ekVt0kTeMvFgmkzZzNPPiAqgAr4H+ww==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@junobuild/plugin-tools/-/plugin-tools-4.1.4.tgz",
+      "integrity": "sha512-oDgtmHfZGUBGJOTuZ5Kv/px6p9P5dmv/f6rLt7TeeOoNkZGZWYA3/euz967P23RCpW5MAMlYyqxKjKkFjHx/Yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@junobuild/config": "^0.4.2"
+        "@junobuild/config": "^2.1.0"
       },
       "peerDependencies": {
-        "@junobuild/config-loader": "^0.3"
-      }
-    },
-    "node_modules/@junobuild/plugin-tools/node_modules/@junobuild/config": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@junobuild/config/-/config-0.4.3.tgz",
-      "integrity": "sha512-S+DdH4Mrcb9Jp1yVyt1DFH0GhK46lCYWBvQK0LR+DPAywnCsIAOJOlfBE2WkYcFzcyRyvR/wIIL5rscwNjj8Kw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@dfinity/zod-schemas": "^1.0.0",
-        "zod": "^3.25"
+        "@junobuild/config-loader": "^0.4.4"
       }
     },
     "node_modules/@junobuild/storage": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@junobuild/storage/-/storage-1.2.0.tgz",
-      "integrity": "sha512-FO2WZFiIeCTO7rEPl48N0HVmyr5jIxDWvjSCEMXv7o9ZHMB/79EozofktyJsBNwbRpDBxRBT4tJuAx6L5PPMjQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@junobuild/storage/-/storage-1.3.2.tgz",
+      "integrity": "sha512-W1e3yx2sYSIFRAW5YPDNpU53hh1f7twoKRHtG4KSBZVIfEKXZUstc5aNSEA3tiQQY8trBGQeQlaj8OeyZeaWGQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@dfinity/agent": "^2.3.0",
-        "@dfinity/candid": "^2.3.0",
-        "@dfinity/identity": "^2.3.0",
-        "@dfinity/principal": "^2.3.0",
-        "@dfinity/utils": "^2",
-        "@junobuild/ic-client": "^2",
+        "@dfinity/agent": "^3.2.6",
+        "@dfinity/candid": "^3.2.6",
+        "@dfinity/identity": "^3.2.6",
+        "@dfinity/principal": "^3.2.6",
+        "@dfinity/utils": "^3.1",
+        "@junobuild/ic-client": "^3",
         "@junobuild/utils": "*"
       }
     },
     "node_modules/@junobuild/utils": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@junobuild/utils/-/utils-0.1.4.tgz",
-      "integrity": "sha512-Mzr6KKT/0Twy/dz7nGwUvIABJXOP3vct7X7dMnQZR8mafJNh0vpLpfGZ3UnKuB8aKnU2KS0LIDPghHcw9qnpmQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@junobuild/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-vx6421VimgGB3y2sMDU9TGHIjlpi/yI1PuwtwNbxTv8q1X+RyNIM2rWirGL6lgHS//89ERMDdSuFgGpJcJHJZA==",
       "license": "MIT",
       "peerDependencies": {
-        "@dfinity/utils": "^2"
+        "@dfinity/utils": "^3.1"
       }
     },
     "node_modules/@junobuild/vite-plugin": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@junobuild/vite-plugin/-/vite-plugin-4.1.4.tgz",
-      "integrity": "sha512-dLqKmmZGGy8nezprrXEqARjVLnt1ouPAPYOGd/hapnHOVApdJsNjI48h0ln+uIaO6E6ErKHscDHsVMz+c2luew==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@junobuild/vite-plugin/-/vite-plugin-4.1.5.tgz",
+      "integrity": "sha512-cCVDG7WdTr8jlJG7IvKiYQMGO0ItVTk9f1g6HpmqsxwfsKdzztmlN6kUFTt+m3OCj9095EMSkDTu4YRgnDrS0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1206,9 +1183,9 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.6.tgz",
-      "integrity": "sha512-GIKz/j99FRthB8icyJQA51E8Uk5hXmdyThjgQXRKiv9h0zeRlzSCLIzFw6K1LotZ3XuB7yzlf76qk7uBmTdFqA==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1945,19 +1922,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/base64-arraybuffer": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
-      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1973,16 +1942,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
@@ -1990,50 +1949,6 @@
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/borc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
-      "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "bignumber.js": "^9.0.0",
-        "buffer": "^5.5.0",
-        "commander": "^2.15.0",
-        "ieee754": "^1.1.13",
-        "iso-url": "~0.4.7",
-        "json-text-sequence": "~0.1.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/borc/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
     },
     "node_modules/brorand": {
       "version": "1.1.0",
@@ -2212,31 +2127,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -2345,13 +2235,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/console-browserify": {
       "version": "1.2.0",
@@ -2463,9 +2346,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2516,13 +2399,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/delimit-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ==",
-      "license": "BSD-2-Clause",
-      "peer": true
     },
     "node_modules/des.js": {
       "version": "1.1.0",
@@ -3018,6 +2894,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3038,6 +2915,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/is-arguments": {
@@ -3161,16 +3039,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/iso-url": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/isomorphic-timers-promises": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz",
@@ -3211,16 +3079,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/json-text-sequence": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-      "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "delimit-stream": "0.1.0"
       }
     },
     "node_modules/json5": {
@@ -4127,6 +3985,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -4211,6 +4070,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4371,13 +4231,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/simple-cbor": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
-      "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==",
-      "license": "ISC",
-      "peer": true
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4415,6 +4268,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -4619,6 +4473,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -12,8 +12,8 @@
     "postinstall": "npm run postinstall:copy-auth"
   },
   "devDependencies": {
-    "@junobuild/config": "^2.1.0",
-    "@junobuild/vite-plugin": "^4.1.4",
+    "@junobuild/config": "^2.2.0",
+    "@junobuild/vite-plugin": "^4.1.5",
     "@tailwindcss/vite": "^4.1.12",
     "autoprefixer": "^10.4.21",
     "prettier": "^3.6.2",
@@ -22,7 +22,7 @@
     "vite-plugin-node-polyfills": "^0.24.0"
   },
   "dependencies": {
-    "@junobuild/core": "^1.2.1",
+    "@junobuild/core": "^2.2.0",
     "nanoid": "^5.1.5"
   }
 }

--- a/demo/src/components/login.js
+++ b/demo/src/components/login.js
@@ -2,10 +2,16 @@ import {signIn} from '@junobuild/core';
 import {addEventClick} from '../utils/utils';
 
 export const renderLogin = (app) => {
+  const signInWithII = async () => {
+    await signIn({
+      internet_identity: {}
+    });
+  };
+
   addEventClick({
     target: app,
     selector: '#login',
-    fn: signIn
+    fn: signInWithII
   });
 
   app.innerHTML = `<button id="login" data-tid="login-button"


### PR DESCRIPTION
# Motivation

I shipped new features on Juno including breaking changes. This PR bumps docs and usage.

# Changes

- The `signIn` feature now requires to explicit specify Internet Identity - it's not the default anymore
- In the CLI, various commands were aliased, like `dev` becoming `emulator`
- There is one breaking change in the CLI, `juno config` becomed `juno config apply`
